### PR TITLE
Added validation to the concurrent action so that if the returned URL…

### DIFF
--- a/actions/cron.go
+++ b/actions/cron.go
@@ -43,7 +43,7 @@ func GetMangaUpdates(job *models.Job, bot *tb.Bot) {
 
 				// Get the last chapter for each manga
 				last, err := feed.GetLastMangaChapter(manga.MangaURL)
-				if err != nil || last == "" {
+				if err != nil || last == "" || last == fmt.Sprintf(feed.ViewManga(), "") {
 					continue // LAter will decide what to do here
 				}
 


### PR DESCRIPTION
… for latest chapter is equal to the base URL of the manga feed, it doesn't notify the user or update the subscription.